### PR TITLE
build: allow builds on arm64 platforms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM adstewart/eleventy:1.0.0
+FROM adstewart/eleventy:1.0.1
 
 WORKDIR /opt/site
 

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ TARGET_PLATFORMS = linux/amd64,linux/arm64
 # it's been created as per the developer notes in HACKING.md.
 docker-build:
 	docker buildx build \
+		--pull \
 		--progress=plain \
 		--builder=multiarch-builder \
 		--cache-from $(IMAGE_NAMESPACE)/$(IMAGE_NAME):$(IMAGE_VERSION) \


### PR DESCRIPTION
updated docker image - should now build on silicon mac or linux arm64.